### PR TITLE
fix: dynamically load strategy modal chart

### DIFF
--- a/components/Strategy/StrategyModal.jsx
+++ b/components/Strategy/StrategyModal.jsx
@@ -3,10 +3,12 @@
 
 import { useEffect, useMemo, useState } from "react";
 import DirectionBadge from "./DirectionBadge";
-import Chart from "./Chart";
+import dynamic from "next/dynamic";
 import PositionBuilder from "./PositionBuilder";
 import SummaryTable from "./SummaryTable";
 import materializeSeeded from "./defs/materializeSeeded";
+
+const Chart = dynamic(() => import("./Chart"), { ssr: false });
 
 // --- centralized strategy aggregator (hub) ---
 // Allow two common export names to avoid churn while migrating.


### PR DESCRIPTION
## Summary
- load Chart via next/dynamic to disable SSR

## Testing
- `npm test` *(fails: expected null to be close to 0.15, difference 0.15, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a527e0c9f48326a19b977122b4b2d2