### PR TITLE
feat: add keepalive health check

### DIFF
--- a/app/keepalive/route.js
+++ b/app/keepalive/route.js
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const IB_PROXY_URL = process.env.IB_PROXY_URL || "http://localhost:4010";
+const headers = {
+  "Cache-Control": "no-store",
+  "Content-Type": "text/plain; charset=utf-8",
+};
+
+export async function GET() {
+  try {
+    const r = await fetch(`${IB_PROXY_URL}/v1/ping`, { cache: "no-store" });
+    if (r.ok) {
+      const j = await r.json().catch(() => ({}));
+      if (j?.ok || j?.up) {
+        return new NextResponse("IB is awake\n", { status: 200, headers });
+      }
+    }
+  } catch (e) {
+    // ignore, fall through to asleep response
+  }
+  return new NextResponse("IB is asleep\n", { status: 503, headers });
+}

--- a/tests/api/keepalive.route.spec.js
+++ b/tests/api/keepalive.route.spec.js
@@ -1,0 +1,30 @@
+// tests/api/keepalive.route.spec.js
+import { GET } from "../../app/keepalive/route";
+import { vi } from "vitest";
+
+describe("keepalive status", () => {
+  const realFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = realFetch;
+  });
+
+  test("reports awake when IB proxy responds", async () => {
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ ok: true, up: true }),
+    }));
+    const res = await GET();
+    const text = await res.text();
+    expect(res.status).toBe(200);
+    expect(text).toMatch(/awake/);
+  });
+
+  test("reports asleep on error", async () => {
+    global.fetch = vi.fn(async () => { throw new Error("fail"); });
+    const res = await GET();
+    const text = await res.text();
+    expect(res.status).toBe(503);
+    expect(text).toMatch(/asleep/);
+  });
+});


### PR DESCRIPTION
## Summary
- add `/keepalive` endpoint that pings the IB proxy and reports if it's awake
- cover keepalive endpoint with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a87dd877dc8326b41e0eba30abb3cf